### PR TITLE
Shorten the mutex lock time in SlamToolbox::updateMap()

### DIFF
--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -400,12 +400,22 @@ bool SlamToolbox::updateMap()
   kt_double occupancy_threshold = 0.0;
   {
     boost::mutex::scoped_lock lock(smapper_mutex_);
-    auto all_scans = smapper_->getMapper()->GetAllProcessedScans();
+    for (const LocalizedRangeScan* scan : smapper_->getMapper()->GetAllProcessedScans()) {
+      LocalizedRangeScan* const copied_scan = new LocalizedRangeScan(
+        scan->GetSensorName(), scan->GetRangeReadingsVector());
+      copied_scan->SetOdometricPose(scan->GetOdometricPose());
+      copied_scan->SetCorrectedPose(scan->GetCorrectedPose());
+      copied_scan->SetTime(scan->GetTime());
+      all_processed_scans.push_back(copied_scan);
+    }
     min_pass_through = (kt_int32u)smapper_->getMapper()->getParamMinPassThrough();
     occupancy_threshold = (kt_double)smapper_->getMapper()->getParamOccupancyThreshold();
   }
   OccupancyGrid *occ_grid = OccupancyGrid::CreateFromScans(
     all_processed_scans, (kt_double)resolution_, min_pass_through, occupancy_threshold);
+  for (auto & scan : all_processed_scans) {
+    delete scan;
+  }
   if (!occ_grid) {
     return false;
   }

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -395,12 +395,20 @@ bool SlamToolbox::updateMap()
   if (sst_->get_subscription_count() == 0) {
     return true;
   }
-  boost::mutex::scoped_lock lock(smapper_mutex_);
-  OccupancyGrid * occ_grid = smapper_->getOccupancyGrid(resolution_);
+  LocalizedRangeScanVector all_processed_scans;
+  kt_int32u min_pass_through = 0;
+  kt_double occupancy_threshold = 0.0;
+  {
+    boost::mutex::scoped_lock lock(smapper_mutex_);
+    auto all_scans = smapper_->getMapper()->GetAllProcessedScans();
+    min_pass_through = (kt_int32u)smapper_->getMapper()->getParamMinPassThrough();
+    occupancy_threshold = (kt_double)smapper_->getMapper()->getParamOccupancyThreshold();
+  }
+  OccupancyGrid *occ_grid = OccupancyGrid::CreateFromScans(
+    all_processed_scans, (kt_double)resolution_, min_pass_through, occupancy_threshold);
   if (!occ_grid) {
     return false;
   }
-
   vis_utils::toNavMap(occ_grid, map_.map);
 
   // publish map as current

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -401,6 +401,9 @@ bool SlamToolbox::updateMap()
   {
     boost::mutex::scoped_lock lock(smapper_mutex_);
     for (const LocalizedRangeScan* scan : smapper_->getMapper()->GetAllProcessedScans()) {
+      if (!scan) {
+        continue;
+      }
       LocalizedRangeScan* const copied_scan = new LocalizedRangeScan(
         scan->GetSensorName(), scan->GetRangeReadingsVector());
       copied_scan->SetOdometricPose(scan->GetOdometricPose());


### PR DESCRIPTION
SlamToolbox::updateMap() において、`smapper_->getOccupancyGrid(resolution_);`の中で呼び出される`OccupancyGrid::CreateFromScans()`関数が非常に時間がかかるため、smapper_mutex_のロック開放待ちでaddScan()関数が長時間待たされてしまう。
このPRでは、mutexのロック中はデータをコピーするだけにして、ロックを開放した後に`OccupancyGrid::CreateFromScans()`を呼び出すように変更した。