### PR TITLE
Enable to use LocalizedRangeScanWithPoints class

### DIFF
--- a/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -699,6 +699,9 @@ public:
   Object(const Object &);
   const Object & operator=(const Object &);
 
+protected:
+  void CloneImpl(Object & rNewObject) const;
+
 private:
   Name m_Name;
   ParameterManager * m_pParameterManager;
@@ -5135,6 +5138,8 @@ protected:
    */
   SensorData(const Name & rSensorName);  // NOLINT
 
+  void CloneImpl(SensorData & rNewSensorData) const;
+
 private:
   /**
    * Restrict the copy constructor
@@ -5313,6 +5318,13 @@ public:
   inline kt_int32u GetNumberOfRangeReadings() const
   {
     return m_NumberOfRangeReadings;
+  }
+
+protected:
+  void CloneImpl(LaserRangeScan & rNewScan) const
+  {
+    SensorData::CloneImpl(rNewScan);
+    rNewScan.SetRangeReadings(GetRangeReadingsVector());
   }
 
 private:
@@ -5636,6 +5648,27 @@ public:
     }
   }
 
+  virtual LocalizedRangeScan * Clone() const
+  {
+    LocalizedRangeScan * const pNewScan =
+        new LocalizedRangeScan(GetSensorName(), GetRangeReadingsVector());
+    CloneImpl(*pNewScan);
+    return pNewScan;
+  }
+
+protected:
+  void CloneImpl(LocalizedRangeScan & rNewScan) const
+  {
+    LaserRangeScan::CloneImpl(rNewScan);
+    rNewScan.m_OdometricPose = m_OdometricPose;
+    rNewScan.m_CorrectedPose = m_CorrectedPose;
+    rNewScan.m_BarycenterPose = m_BarycenterPose;
+    rNewScan.m_PointReadings = m_PointReadings;
+    rNewScan.m_UnfilteredPointReadings = m_UnfilteredPointReadings;
+    rNewScan.m_BoundingBox = m_BoundingBox;
+    rNewScan.m_IsDirty = m_IsDirty;
+  }
+
 private:
   /**
    * Compute point readings based on range readings
@@ -5794,11 +5827,22 @@ public:
   {
   }
 
+  LocalizedRangeScanWithPoints()
+  {}
+
   /**
    * Destructor
    */
   virtual ~LocalizedRangeScanWithPoints()
   {
+  }
+
+  virtual LocalizedRangeScan * Clone() const
+  {
+    LocalizedRangeScanWithPoints * const pNewScan =
+      new LocalizedRangeScanWithPoints(GetSensorName(), GetRangeReadingsVector(), m_Points);
+    LocalizedRangeScan::CloneImpl(*pNewScan);
+    return pNewScan;
   }
 
 private:
@@ -5859,8 +5903,16 @@ private:
   LocalizedRangeScanWithPoints(const LocalizedRangeScanWithPoints &);
   const LocalizedRangeScanWithPoints & operator=(const LocalizedRangeScanWithPoints &);
 
+  friend class boost::serialization::access;
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & BOOST_SERIALIZATION_NVP(m_Points);
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(LocalizedRangeScan);
+  }
+
 private:
-  const PointVectorDouble m_Points;
+  PointVectorDouble m_Points;
 };    // LocalizedRangeScanWithPoints
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -7039,5 +7091,6 @@ BOOST_CLASS_EXPORT_KEY(karto::Parameter<kt_bool>);
 BOOST_CLASS_EXPORT_KEY(karto::Parameter<kt_int32u>);
 BOOST_CLASS_EXPORT_KEY(karto::Parameter<kt_int32s>);
 BOOST_CLASS_EXPORT_KEY(karto::Parameter<std::string>);
+BOOST_CLASS_EXPORT_KEY(karto::LocalizedRangeScanWithPoints);
 
 #endif  // KARTO_SDK__KARTO_H_

--- a/lib/karto_sdk/src/Karto.cpp
+++ b/lib/karto_sdk/src/Karto.cpp
@@ -49,6 +49,7 @@ BOOST_CLASS_EXPORT_IMPLEMENT(karto::Parameter<kt_bool>);
 BOOST_CLASS_EXPORT_IMPLEMENT(karto::Parameter<kt_int32u>);
 BOOST_CLASS_EXPORT_IMPLEMENT(karto::Parameter<kt_int32s>);
 BOOST_CLASS_EXPORT_IMPLEMENT(karto::Parameter<std::string>);
+BOOST_CLASS_EXPORT_IMPLEMENT(karto::LocalizedRangeScanWithPoints);
 namespace karto
 {
 
@@ -81,6 +82,14 @@ Object::~Object()
 {
   delete m_pParameterManager;
   m_pParameterManager = NULL;
+}
+
+void Object::CloneImpl(Object & rNewObject) const
+{
+  rNewObject.m_Name = m_Name;
+  for (const auto & parameter : m_pParameterManager->GetParameterVector()) {
+    rNewObject.m_pParameterManager->Add(parameter->Clone());
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -131,6 +140,15 @@ SensorData::~SensorData()
   }
 
   m_CustomData.clear();
+}
+
+void SensorData::CloneImpl(SensorData & rNewSensorData) const
+{
+  Object::CloneImpl(rNewSensorData);
+  rNewSensorData.m_StateId = m_StateId;
+  rNewSensorData.m_UniqueId = m_UniqueId;
+  rNewSensorData.m_SensorName = m_SensorName;
+  rNewSensorData.m_Time = m_Time;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -404,12 +404,7 @@ bool SlamToolbox::updateMap()
       if (!scan) {
         continue;
       }
-      LocalizedRangeScan* const copied_scan = new LocalizedRangeScan(
-        scan->GetSensorName(), scan->GetRangeReadingsVector());
-      copied_scan->SetOdometricPose(scan->GetOdometricPose());
-      copied_scan->SetCorrectedPose(scan->GetCorrectedPose());
-      copied_scan->SetTime(scan->GetTime());
-      all_processed_scans.push_back(copied_scan);
+      all_processed_scans.push_back(scan->Clone());
     }
     min_pass_through = (kt_int32u)smapper_->getMapper()->getParamMinPassThrough();
     occupancy_threshold = (kt_double)smapper_->getMapper()->getParamOccupancyThreshold();


### PR DESCRIPTION
- `LocalizedRangeScanWithPoints` class is updated to be serialized and deserialized by the boost::serialization library.
- `Clone()` method is added to `LocalizedRangeScan` and  `LocalizedRangeScanWithPoints` classes. It is used to copy instances while constructing grid maps.
  - `CloneImpl()` methods are added to their parent classes to copy private members.