### PR TITLE
Modify some functions to use them outside the package

### DIFF
--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -815,6 +815,19 @@ public:
    */
   void UpdateLoopScanMatcher(kt_double rangeThreshold);
 
+  /**
+   * Link the chain of scans to the given scan by finding the closest scan in the chain to the given scan
+   * @param rChain
+   * @param pScan
+   * @param rMean
+   * @param rCovariance
+   */
+  void LinkChainToScan(
+    const LocalizedRangeScanVector & rChain,
+    LocalizedRangeScan * pScan,
+    const Pose2 & rMean,
+    const Matrix3 & rCovariance);
+
 private:
   /**
    * Gets the vertex associated with the given scan
@@ -866,19 +879,6 @@ private:
   void LinkNearChains(
     LocalizedRangeScan * pScan, Pose2Vector & rMeans,
     std::vector<Matrix3> & rCovariances);
-
-  /**
-   * Link the chain of scans to the given scan by finding the closest scan in the chain to the given scan
-   * @param rChain
-   * @param pScan
-   * @param rMean
-   * @param rCovariance
-   */
-  void LinkChainToScan(
-    const LocalizedRangeScanVector & rChain,
-    LocalizedRangeScan * pScan,
-    const Pose2 & rMean,
-    const Matrix3 & rCovariance);
 
   /**
    * Find chains of scans that are close to given scan

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -299,7 +299,7 @@ LocalizedRangeScan * MapperSensorManager::GetScan(const Name & rSensorName, kt_i
  * @param pLaserRangeFinder
  * @return last localized range scan of device
  */
-inline LocalizedRangeScan * MapperSensorManager::GetLastScan(const Name & rSensorName)
+LocalizedRangeScan * MapperSensorManager::GetLastScan(const Name & rSensorName)
 {
   RegisterSensor(rSensorName);
 
@@ -348,7 +348,7 @@ void MapperSensorManager::AddScan(LocalizedRangeScan * pScan)
  * Adds scan to running scans of device that recorded scan
  * @param pScan
  */
-inline void MapperSensorManager::AddRunningScan(LocalizedRangeScan * pScan)
+void MapperSensorManager::AddRunningScan(LocalizedRangeScan * pScan)
 {
   GetScanManager(pScan)->AddRunningScan(pScan);
 }
@@ -375,7 +375,7 @@ void MapperSensorManager::RemoveScan(LocalizedRangeScan * pScan)
  * @param rSensorName
  * @return scans of device
  */
-inline LocalizedRangeScanMap & MapperSensorManager::GetScans(const Name & rSensorName)
+LocalizedRangeScanMap & MapperSensorManager::GetScans(const Name & rSensorName)
 {
   return GetScanManager(rSensorName)->GetScans();
 }
@@ -385,7 +385,7 @@ inline LocalizedRangeScanMap & MapperSensorManager::GetScans(const Name & rSenso
  * @param rSensorName
  * @return running scans of device
  */
-inline LocalizedRangeScanVector & MapperSensorManager::GetRunningScans(const Name & rSensorName)
+LocalizedRangeScanVector & MapperSensorManager::GetRunningScans(const Name & rSensorName)
 {
   return GetScanManager(rSensorName)->GetRunningScans();
 }
@@ -395,7 +395,7 @@ void MapperSensorManager::ClearRunningScans(const Name & rSensorName)
   GetScanManager(rSensorName)->ClearRunningScans();
 }
 
-inline kt_int32u MapperSensorManager::GetRunningScanBufferSize(const Name & rSensorName)
+kt_int32u MapperSensorManager::GetRunningScanBufferSize(const Name & rSensorName)
 {
   return GetScanManager(rSensorName)->GetRunningScanBufferSize();
 }


### PR DESCRIPTION
- `MapperGraph::LinkChainToScan()` is changed to a public function.
- Some invalid `inline` keywords in cpp are removed to avoid undefined reference errors outside of the slam_toolbox package.