### PR TITLE
Add an option to randomize orders of the near link chain

### DIFF
--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2366,6 +2366,8 @@ protected:
 
   Parameter<kt_int32u> * m_pMaximumNearChainLinkSize;
 
+  Parameter<kt_bool> * m_pRandomizeNearChainOrder;
+
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int version)
@@ -2459,6 +2461,7 @@ public:
   int getParamMinPassThrough();
   double getParamOccupancyThreshold();
   int getParamMaximumNearChainLinkSize();
+  bool getParamRandomizeNearChainOrder();
 
   /* Setters */
   // General Parameters
@@ -2500,6 +2503,7 @@ public:
   void setParamMinPassThrough(int i);
   void setParamOccupancyThreshold(double d);
   void setParamMaximumNearChainLinkSize(int i);
+  void setParamRandomizeNearChainOrder(bool b);
 };
 BOOST_SERIALIZATION_ASSUME_ABSTRACT(Mapper)
 }  // namespace karto

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -26,6 +26,7 @@
 #include <chrono>
 #include <utility>
 #include <string>
+#include <random>
 
 #include "tbb/parallel_for_each.h"
 #include "tbb/parallel_for.h"
@@ -927,7 +928,7 @@ private:
   GraphTraversal<LocalizedRangeScan> * m_pTraversal;
 
   // Random generator for near chain shuffling (not serialized)
-  std::mt19937 m_NearChainShuffleGen;
+  std::mt19937 * m_pNearChainShuffleGen;
 
   /**
    * Serialization: class MapperGraph
@@ -944,7 +945,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(m_pLoopScanMatcher);
     std::cout << "MapperGraph <- m_pTraversal\n";
     ar & BOOST_SERIALIZATION_NVP(m_pTraversal);
-    // m_NearChainShuffleGen is intentionally not serialized
+    // m_pNearChainShuffleGen is intentionally not serialized
   }
 };    // MapperGraph
 

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -926,6 +926,9 @@ private:
    */
   GraphTraversal<LocalizedRangeScan> * m_pTraversal;
 
+  // Random generator for near chain shuffling (not serialized)
+  std::mt19937 m_NearChainShuffleGen;
+
   /**
    * Serialization: class MapperGraph
    */
@@ -941,6 +944,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(m_pLoopScanMatcher);
     std::cout << "MapperGraph <- m_pTraversal\n";
     ar & BOOST_SERIALIZATION_NVP(m_pTraversal);
+    // m_NearChainShuffleGen is intentionally not serialized
   }
 };    // MapperGraph
 

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -32,6 +32,8 @@
 #include <utility>
 #include <algorithm>
 #include <string>
+#include <numeric>
+#include <random>
 
 #include "karto_sdk/Mapper.h"
 
@@ -1641,22 +1643,31 @@ void MapperGraph::LinkNearChains(
   std::vector<Matrix3> & rCovariances)
 {
   const std::vector<LocalizedRangeScanVector> nearChains = FindNearChains(pScan);
+  if (nearChains.empty()) {
+    return;
+  }
   kt_int32u linkedScans = 0;
-  const_forEach(std::vector<LocalizedRangeScanVector>, &nearChains)
-  {
-    if (iter->size() < m_pMapper->m_pLoopMatchMinimumChainSize->GetValue()) {
+  std::vector<size_t> chainIndices(nearChains.size());
+  std::iota(chainIndices.begin(), chainIndices.end(), 0);
+  if (m_pMapper->m_pRandomizeNearChainOrder->GetValue()) {
+    static thread_local std::mt19937 gen{std::random_device{}()};
+    std::shuffle(chainIndices.begin(), chainIndices.end(), gen);
+  }
+  for (size_t idx : chainIndices) {
+    const LocalizedRangeScanVector & chain = nearChains[idx];
+    if (chain.size() < m_pMapper->m_pLoopMatchMinimumChainSize->GetValue()) {
       continue;
     }
 
     Pose2 mean;
     Matrix3 covariance;
     // match scan against "near" chain
-    kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan(pScan, *iter, mean,
+    kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan(pScan, chain, mean,
         covariance, false);
     if (response > m_pMapper->m_pLinkMatchMinimumResponseFine->GetValue() - KT_TOLERANCE) {
       rMeans.push_back(mean);
       rCovariances.push_back(covariance);
-      LinkChainToScan(*iter, pScan, mean, covariance);
+      LinkChainToScan(chain, pScan, mean, covariance);
       ++linkedScans;
       if (linkedScans >= m_pMapper->m_pMaximumNearChainLinkSize->GetValue()) {
         // stop searching for more chains
@@ -2315,6 +2326,11 @@ void Mapper::InitializeParameters()
     "Maximum number of scans in a near chain.  If the number of scans in a "
     "near chain exceeds this value, the chain will not be used for linking.",
     std::numeric_limits<kt_int32u>::max(), GetParameterManager());
+
+  m_pRandomizeNearChainOrder = new Parameter<kt_bool>(
+    "RandomizeNearChainOrder",
+    "Randomize the order of near chain links for loop closure.",
+    false, GetParameterManager());
 }
 /* Adding in getters and setters here for easy parameter access */
 
@@ -2486,6 +2502,10 @@ int Mapper::getParamMaximumNearChainLinkSize()
   return static_cast<int>(m_pMaximumNearChainLinkSize->GetValue());
 }
 
+bool Mapper::getParamRandomizeNearChainOrder()
+{
+  return static_cast<bool>(m_pRandomizeNearChainOrder->GetValue());
+}
 
 /* Setters for parameters */
 // General Parameters
@@ -2652,6 +2672,11 @@ void Mapper::setParamOccupancyThreshold(double d)
 void Mapper::setParamMaximumNearChainLinkSize(int i)
 {
   m_pMaximumNearChainLinkSize->SetValue((kt_int32u)i);
+}
+
+void Mapper::setParamRandomizeNearChainOrder(bool b)
+{
+  m_pRandomizeNearChainOrder->SetValue((kt_bool)b);
 }
 
 void Mapper::Initialize(kt_double rangeThreshold)

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -1653,8 +1653,8 @@ void MapperGraph::LinkNearChains(
     static thread_local std::mt19937 gen{std::random_device{}()};
     std::shuffle(chainIndices.begin(), chainIndices.end(), gen);
   }
-  for (size_t idx : chainIndices) {
-    const LocalizedRangeScanVector & chain = nearChains[idx];
+  for (const size_t index : chainIndices) {
+    const LocalizedRangeScanVector & chain = nearChains[index];
     if (chain.size() < m_pMapper->m_pLoopMatchMinimumChainSize->GetValue()) {
       continue;
     }
@@ -1662,7 +1662,7 @@ void MapperGraph::LinkNearChains(
     Pose2 mean;
     Matrix3 covariance;
     // match scan against "near" chain
-    kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan(pScan, chain, mean,
+    const kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan(pScan, chain, mean,
         covariance, false);
     if (response > m_pMapper->m_pLinkMatchMinimumResponseFine->GetValue() - KT_TOLERANCE) {
       rMeans.push_back(mean);

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2333,10 +2333,12 @@ void Mapper::InitializeParameters()
 
   m_pRandomizeNearChainOrder = new Parameter<kt_bool>(
     "RandomizeNearChainOrder",
-    "Randomize the order of near chain links for loop closure.",
+    "Randomize the order of near chain links for loop closure. Use this in conjunction with "
+    "MaximumNearChainLinkSize to avoid repeatedly evaluating the same subset of links.",
     false, GetParameterManager());
 }
 /* Adding in getters and setters here for easy parameter access */
+
 
 // General Parameters
 

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -1650,8 +1650,10 @@ void MapperGraph::LinkNearChains(
   std::vector<size_t> chainIndices(nearChains.size());
   std::iota(chainIndices.begin(), chainIndices.end(), 0);
   if (m_pMapper->m_pRandomizeNearChainOrder->GetValue()) {
-    static thread_local std::mt19937 gen{std::random_device{}()};
-    std::shuffle(chainIndices.begin(), chainIndices.end(), gen);
+    if (m_NearChainShuffleGen == std::mt19937{}) {
+      m_NearChainShuffleGen.seed(std::random_device{}());
+    }
+    std::shuffle(chainIndices.begin(), chainIndices.end(), m_NearChainShuffleGen);
   }
   for (const size_t index : chainIndices) {
     const LocalizedRangeScanVector & chain = nearChains[index];
@@ -1662,7 +1664,7 @@ void MapperGraph::LinkNearChains(
     Pose2 mean;
     Matrix3 covariance;
     // match scan against "near" chain
-    const kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan(pScan, chain, mean,
+    kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan(pScan, chain, mean,
         covariance, false);
     if (response > m_pMapper->m_pLinkMatchMinimumResponseFine->GetValue() - KT_TOLERANCE) {
       rMeans.push_back(mean);

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -1403,6 +1403,7 @@ MapperGraph::MapperGraph(Mapper * pMapper, kt_double rangeThreshold)
   assert(m_pLoopScanMatcher);
 
   m_pTraversal = new BreadthFirstTraversal<LocalizedRangeScan>(this);
+  m_pNearChainShuffleGen = new std::mt19937(std::random_device{}());
 }
 
 MapperGraph::~MapperGraph()
@@ -1414,6 +1415,10 @@ MapperGraph::~MapperGraph()
   if (m_pTraversal) {
     delete m_pTraversal;
     m_pTraversal = NULL;
+  }
+  if (m_pNearChainShuffleGen) {
+    delete m_pNearChainShuffleGen;
+    m_pNearChainShuffleGen = NULL;
   }
 }
 
@@ -1650,10 +1655,7 @@ void MapperGraph::LinkNearChains(
   std::vector<size_t> chainIndices(nearChains.size());
   std::iota(chainIndices.begin(), chainIndices.end(), 0);
   if (m_pMapper->m_pRandomizeNearChainOrder->GetValue()) {
-    if (m_NearChainShuffleGen == std::mt19937{}) {
-      m_NearChainShuffleGen.seed(std::random_device{}());
-    }
-    std::shuffle(chainIndices.begin(), chainIndices.end(), m_NearChainShuffleGen);
+    std::shuffle(chainIndices.begin(), chainIndices.end(), *m_pNearChainShuffleGen);
   }
   for (const size_t index : chainIndices) {
     const LocalizedRangeScanVector & chain = nearChains[index];

--- a/src/slam_mapper.cpp
+++ b/src/slam_mapper.cpp
@@ -355,7 +355,6 @@ void SMapper::configure(const rclcpp::Node::SharedPtr & node)
   node->get_parameter("use_response_expansion", use_response_expansion);
   mapper_->setParamUseResponseExpansion(use_response_expansion);
 
-
   int min_pass_through = 2;
   if (!node->has_parameter("min_pass_through")) {
     node->declare_parameter("min_pass_through", min_pass_through);
@@ -376,6 +375,13 @@ void SMapper::configure(const rclcpp::Node::SharedPtr & node)
   }
   node->get_parameter("maximum_near_chain_link_size", maximum_near_chain_link_size);
   mapper_->setParamMaximumNearChainLinkSize(maximum_near_chain_link_size);
+
+  bool randomize_near_chain_order = false;
+  if (!node->has_parameter("randomize_near_chain_order")) {
+    node->declare_parameter("randomize_near_chain_order", randomize_near_chain_order);
+  }
+  node->get_parameter("randomize_near_chain_order", randomize_near_chain_order);
+  mapper_->setParamRandomizeNearChainOrder(randomize_near_chain_order);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Parameter `randomize_near_chain_order` is added. When it is true, the indices of the near chains in `MapperGraph::LinkNearChains()` is randomized. 
This is used with the `maximum_near_chain_link_size` parameter to avoid the performance bottle neck in `MapperGraph::LinkNearChains()`.

 